### PR TITLE
get_address内、lookup_hostが空を返したときの対策(issue #37)

### DIFF
--- a/src/ssh_connect.rs
+++ b/src/ssh_connect.rs
@@ -40,7 +40,7 @@ fn get_address(opt: &Opt, host_params: &HostParams) -> Result<std::net::SocketAd
         .collect::<Vec<_>>();
     let addr = addr
         .first()
-        .ok_or(anyhow!("Unable to obtain DNS addres."))
+        .ok_or(anyhow!("Unable to obtain DNS address."))
         .inspect_err(|e| error!("get_address : {}", e))?;
     Ok(std::net::SocketAddr::from((*addr, opt.port)))
 }


### PR DESCRIPTION
get_address内でlookup_hostの戻り値を適切に処理するよう修正(issue #37)

- lookup_hostの戻り値配列を、first()で参照し、None時はエラーを返すように変更。(アドレスが取得できない場合、致命的と思われるので、上位に判断を任せる)
- get_address内でのエラー発生時、errorログを記録する処理を追加

fixed #37
